### PR TITLE
just for review: CIAMAUTHZ-6077 consistent language fallbacks for admin ui theme

### DIFF
--- a/apps/admin-ui/cypress/e2e/i18n_test.spec.ts
+++ b/apps/admin-ui/cypress/e2e/i18n_test.spec.ts
@@ -1,0 +1,185 @@
+import LoginPage from "../support/pages/LoginPage";
+import SidebarPage from "../support/pages/admin-ui/SidebarPage";
+import adminClient from "../support/util/AdminClient";
+import { keycloakBefore } from "../support/util/keycloak_hooks";
+import ProviderPage from "../support/pages/admin-ui/manage/providers/ProviderPage";
+
+const loginPage = new LoginPage();
+const sidebarPage = new SidebarPage();
+
+const providersPage = new ProviderPage();
+
+const usernameI18nTest = "user_i18n_test";
+let usernameI18nId: string;
+
+let pageLoaded: boolean = false;
+let originallySupportedLocales: string[];
+
+describe("i18n tests", () => {
+  before(() => {
+    cy.wrap(null).then(async () => {
+      const realm = (await adminClient.getRealm("master"))!;
+      originallySupportedLocales = realm.supportedLocales ?? [];
+      realm.supportedLocales = ["en", "de", "de-CH", "fo"];
+      await adminClient.updateRealm("master", realm);
+
+      const { id: userId } = await adminClient.createUser({
+        username: usernameI18nTest,
+        enabled: true,
+        credentials: [
+          { type: "password", temporary: false, value: usernameI18nTest },
+        ],
+      });
+      usernameI18nId = userId;
+
+      await adminClient.addRealmRoleToUser(usernameI18nId, "admin");
+    });
+
+    keycloakBefore();
+  });
+
+  after(async () => {
+    await adminClient.deleteUser(usernameI18nTest);
+
+    if (originallySupportedLocales != null) {
+      const realm = (await adminClient.getRealm("master"))!;
+      realm.supportedLocales = originallySupportedLocales;
+      await adminClient.updateRealm("master", realm);
+    }
+  });
+
+  afterEach(async () => {
+    await adminClient.removeAllLocalizationTexts();
+  });
+
+  const realmLocalizationEn = "realmSettings en";
+  const themeLocalizationEn = "Realm settings";
+  const realmLocalizationDe = "realmSettings de";
+  const themeLocalizationDe = "Realm-Einstellungen";
+  const realmLocalizationDeCh = "realmSettings de-CH";
+
+  it("should use THEME localization for fallback (en) when language without theme localization is requested and no realm localization exists", () => {
+    updateUserLocale("fo");
+
+    openOrReloadUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(themeLocalizationEn);
+  });
+
+  it("should use THEME localization for language when language with theme localization is requested and no realm localization exists", () => {
+    updateUserLocale("de");
+
+    openOrReloadUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(themeLocalizationDe);
+  });
+
+  it("should use REALM localization for fallback (en) when language without theme localization is requested and realm localization exists for fallback (en)", () => {
+    addCommonRealmSettingsLocalizationText("en", realmLocalizationEn);
+    updateUserLocale("fo");
+
+    openOrReloadUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationEn);
+  });
+
+  it("should use THEME localization for language when language with theme localization is requested and realm localization exists for fallback (en) only", () => {
+    addCommonRealmSettingsLocalizationText("en", realmLocalizationEn);
+    updateUserLocale("de");
+
+    openOrReloadUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(themeLocalizationDe);
+  });
+
+  it("should use REALM localization for language when language is requested and realm localization exists for language", () => {
+    addCommonRealmSettingsLocalizationText("de", realmLocalizationDe);
+    updateUserLocale("de");
+
+    openOrReloadUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationDe);
+  });
+
+  it("should use REALM localization for region when region is requested and realm localization exists for region", () => {
+    addCommonRealmSettingsLocalizationText("de-CH", realmLocalizationDeCh);
+    updateUserLocale("de-CH");
+
+    openOrReloadUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationDeCh);
+  });
+
+  it("should use REALM localization for language when language is requested and realm localization exists for fallback (en), language, region", () => {
+    addCommonRealmSettingsLocalizationText("en", realmLocalizationEn);
+    addCommonRealmSettingsLocalizationText("de", realmLocalizationDe);
+    addCommonRealmSettingsLocalizationText("de-CH", realmLocalizationDeCh);
+    updateUserLocale("de");
+
+    openOrReloadUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationDe);
+  });
+
+  it("should use REALM localization for language when region is requested and realm localization exists for fallback (en), language", () => {
+    addCommonRealmSettingsLocalizationText("en", realmLocalizationEn);
+    addCommonRealmSettingsLocalizationText("de", realmLocalizationDe);
+    updateUserLocale("de-CH");
+
+    openOrReloadUserFederationPage();
+
+    sidebarPage.checkRealmSettingsLinkContainsText(realmLocalizationDe);
+  });
+
+  it("should apply plurals and interpolation for THEME localization", () => {
+    updateUserLocale("en");
+
+    openOrReloadUserFederationPage();
+
+    // check key "user-federation:addProvider_other"
+    providersPage.assertCardContainsText("ldap", "Add Ldap providers");
+  });
+
+  it("should apply plurals and interpolation for REALM localization", () => {
+    addLocalization(
+      "en",
+      "user-federation:addProvider_other",
+      "addProvider_other en: {{provider}}"
+    );
+    updateUserLocale("en");
+
+    openOrReloadUserFederationPage();
+
+    providersPage.assertCardContainsText("ldap", "addProvider_other en: Ldap");
+  });
+
+  function openOrReloadUserFederationPage() {
+    if (!pageLoaded) {
+      loginPage.logIn(usernameI18nTest, usernameI18nTest);
+      sidebarPage.goToUserFederation();
+      pageLoaded = true;
+    } else {
+      cy.reload();
+      sidebarPage.waitForPageLoad();
+    }
+  }
+
+  function updateUserLocale(locale: string) {
+    cy.wrap(null).then(() =>
+      adminClient.updateUser(usernameI18nId, { attributes: { locale: locale } })
+    );
+  }
+
+  function addCommonRealmSettingsLocalizationText(
+    locale: string,
+    value: string
+  ) {
+    addLocalization(locale, "common:realmSettings", value);
+  }
+
+  function addLocalization(locale: string, key: string, value: string) {
+    cy.wrap(null).then(() =>
+      adminClient.addLocalizationText(locale, key, value)
+    );
+  }
+});

--- a/apps/admin-ui/cypress/support/pages/admin-ui/SidebarPage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/SidebarPage.ts
@@ -142,4 +142,8 @@ export default class SidebarPage extends CommonElements {
     cy.get('[role="progressbar"]').should("not.exist");
     return this;
   }
+
+  checkRealmSettingsLinkContainsText(expectedText: string) {
+    cy.get(this.realmSettingsBtn).should("contain", expectedText);
+  }
 }

--- a/apps/admin-ui/cypress/support/pages/admin-ui/manage/providers/ProviderPage.ts
+++ b/apps/admin-ui/cypress/support/pages/admin-ui/manage/providers/ProviderPage.ts
@@ -430,6 +430,11 @@ export default class ProviderPage {
     return this;
   }
 
+  assertCardContainsText(providerType: string, expectedText: string) {
+    cy.findByTestId(`${providerType}-card`).should("contain", expectedText);
+    return this;
+  }
+
   disableEnabledSwitch(providerType: string) {
     cy.get(`#${providerType}-switch`).uncheck({ force: true });
     return this;

--- a/apps/admin-ui/src/context/whoami/WhoAmI.tsx
+++ b/apps/admin-ui/src/context/whoami/WhoAmI.tsx
@@ -12,7 +12,8 @@ export class WhoAmI {
   constructor(private me?: WhoAmIRepresentation) {
     if (this.me?.locale) {
       i18n.changeLanguage(this.me.locale, (error) => {
-        if (error) console.error("Unable to set locale to", this.me?.locale);
+        if (error)
+          console.warn("Error(s) loading locale", this.me?.locale, error);
       });
     }
   }

--- a/apps/admin-ui/src/i18n.ts
+++ b/apps/admin-ui/src/i18n.ts
@@ -1,4 +1,4 @@
-import { init, use, InitOptions, TOptions } from "i18next";
+import i18n, { init, use, InitOptions } from "i18next";
 import HttpBackend, { LoadPathOption } from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
 import type KeycloakAdminClient from "@keycloak/keycloak-admin-client";
@@ -8,10 +8,61 @@ import { getAuthorizationHeaders } from "./utils/getAuthorizationHeaders";
 import { addTrailingSlash } from "./util";
 
 export const DEFAULT_LOCALE = "en";
+const OVERRIDES_NS = "overrides";
 
 export async function initI18n(adminClient: KeycloakAdminClient) {
   const options = await initOptions(adminClient);
   await init(options);
+
+  addInterceptorForGetResource();
+}
+
+/**
+ * Intercept the "getResource" function of the resource store, in order to apply the "overrides" from realm localization.
+ *
+ * An alternative would be to use a postProcessor, but to make that work, almost all the default processing logic
+ * would need to be re-implemented here.
+ * Several functionality cannot be easily supported with a postProcessor:
+ * <ul>
+ *     <li>The key might or might not contain the namespace, thus key parsing would need to be re-implemented.</li>
+ *     <li>In case of plurals, the key will not contain the "_one" or "_other" suffix - would need to be re-implemented</li>
+ *     <li>For the "overrides", interpolation (replacing placeholders) would need to be applied.</li>
+ *     <li>Probably more ...</li>
+ * </ul>
+ */
+function addInterceptorForGetResource() {
+  const functionNameGetResource = "getResource";
+  const i18nStore = i18n.store as any;
+  const originalGetResource = i18nStore[functionNameGetResource];
+  const interceptGetResource: any = (
+    lng: string,
+    ns: string,
+    key: any,
+    originalOptions?: Pick<InitOptions, "keySeparator" | "ignoreJSONStructure">
+  ) => {
+    // key undefined means this is just a check whether a resource bundle exists
+    if (key === undefined) {
+      return originalGetResource.apply(i18nStore, [lng, ns]);
+    }
+
+    const options = originalOptions !== undefined ? originalOptions : {};
+
+    const realmLocalizationKey = ns + ":" + key;
+    const override = originalGetResource.apply(i18nStore, [
+      lng,
+      OVERRIDES_NS,
+      realmLocalizationKey,
+      options,
+    ]);
+    if (ns === OVERRIDES_NS) {
+      return override;
+    }
+
+    return (
+      override || originalGetResource.apply(i18nStore, [lng, ns, key, options])
+    );
+  };
+  i18nStore[functionNameGetResource] = interceptGetResource;
 }
 
 const initOptions = async (
@@ -21,7 +72,7 @@ const initOptions = async (
     if (namespaces[0] === "overrides") {
       return `${addTrailingSlash(adminClient.baseUrl)}admin/realms/${
         adminClient.realmName
-      }/localization/{{lng}}?useRealmDefaultLocaleFallback=true`;
+      }/localization/{{lng}}`;
     } else {
       return `${environment.resourceUrl}/resources/{{lng}}/{{ns}}.json`;
     }
@@ -56,12 +107,11 @@ const initOptions = async (
       "identity-providers",
       "identity-providers-help",
       "dynamic",
-      "overrides",
+      OVERRIDES_NS,
     ],
     interpolation: {
       escapeValue: false,
     },
-    postProcess: ["overrideProcessor"],
     backend: {
       loadPath: constructLoadPath,
       customHeaders: getAuthorizationHeaders(
@@ -71,16 +121,6 @@ const initOptions = async (
   };
 };
 
-const configuredI18n = use({
-  type: "postProcessor",
-  name: "overrideProcessor",
-  process: function (value: string, key: string, _: TOptions, translator: any) {
-    const override: string =
-      translator.resourceStore.data[translator.language].overrides?.[key];
-    return override || value;
-  },
-})
-  .use(initReactI18next)
-  .use(HttpBackend);
+const configuredI18n = use(initReactI18next).use(HttpBackend);
 
 export default configuredI18n;


### PR DESCRIPTION
- i18next does not support variants, hence the prio of messages is as follows (RL = realm localization, T = Theme i18n files): RL <region> > T <region> > RL <language> > T <language> > RL en > T en
- remove the param useRealmDefaultLocaleFallback=true from the call to /admin/realms/{realm}/localization/{locale}, because otherwise realm localization texts of the realm default language would overwrite more specific texts from translation files (and unnecessary data will be loaded)
- add cypress test i18n_test.spec.ts, which checks the fallback implementation
- log a warning instead of an error, when messages for some languages/namespaces cannot be loaded (the page will probably work with fallbacks in that case)

## Motivation
<!-- Add references to relevant tickets, issues, design specs and/or a short description of what motivated you to do it. -->

## Brief Description
<!-- Add a short answer for: 
What was done in this PR? (e.g Fix to prevent users from accessing feature X.)
Why it was done? (e.g Feature X was deprecated.)
-->

## Verification Steps
<!--
Add the steps required to verify this change. Keep in mind that these steps should be written so groups unfamiliar with the 
new functionality can follow them, such as QE or documentation.

1. Go to `XX >> YY >> SS`.
2. Create a new item `N` with info `X`.
3. Right-click the item and select Delete.
4. Verify that the item is no longer present in the left navigation menu.
-->

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] User-visible strings are using the react-i18next framework (useTranslation)
- [ ] Help has been implemented
- [ ] axe report has been run and resulting a11y issues have been resolved
- [x] Unit tests have been created/updated

## Additional Notes
<!-- 
Add images and/or screen caps to illustrate what was changed if this pull request adds to or modifies existing user-visible appearance/output. 
-->
